### PR TITLE
readme: fix link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ transit-dart
 [Transit](http://transit-format.org) format.
 
 Before reading this you should be familiar with the
-Transit format ([http://transit-format.org]())
+Transit format (<http://transit-format.org>)
 
 Usage
 -----


### PR DESCRIPTION
Note angle-bracket links are recognized by both [GFM](https://help.github.com/articles/github-flavored-markdown/#url-autolinking) and [CommonMark](http://spec.commonmark.org/0.12/#autolink).
